### PR TITLE
Remove SD.h dependency from the library so better SD libraries like SdFat can be used

### DIFF
--- a/codecfile.h
+++ b/codecfile.h
@@ -1,0 +1,79 @@
+#include "codecs.h"
+#include <SD.h>
+
+class CodecFile : public CodecFileBase
+{
+public:
+
+	bool fopen(const char *filename) {ftype=codec_file; AudioStartUsingSPI(); fptr=NULL; file=SD.open(filename); _fsize=file.size(); _fposition=0; return file != 0;} //FILE
+	bool fopen(const uint8_t*p, const size_t size) {ftype=codec_flash; fptr=(uint8_t*)p; _fsize=size; _fposition=0; return true;} //FLASH
+	bool fopen(const size_t p, const size_t size) {ftype=codec_serflash; offset=p; _fsize=size; _fposition=0; AudioStartUsingSPI(); serflashinit(); return true;} //SERIAL FLASH
+	void fclose(void)
+	{
+		_fsize=_fposition=0; fptr=NULL;
+		if (ftype==codec_file) {file.close(); AudioStopUsingSPI();}
+		else
+		if (ftype==codec_serflash) {AudioStopUsingSPI();}
+		ftype=codec_none;
+	}
+	bool f_eof(void) {return _fposition >= _fsize;}
+	bool fseek(const size_t position) {_fposition=position;if (ftype==codec_file) return file.seek(_fposition)!=0; else return _fposition <= _fsize;}
+	size_t fposition(void) {return _fposition;}
+	size_t fsize(void) {return _fsize;}
+	size_t fread(uint8_t buffer[],size_t bytes){
+		if (_fposition + bytes > _fsize) bytes = _fsize - _fposition;
+		switch (ftype) {
+			case codec_none : bytes = 0; break;
+			case codec_file : bytes = file.read(buffer, bytes); break;
+			case codec_flash: memcpy(buffer, _fposition + fptr, bytes); break;
+			case codec_serflash: readserflash(buffer, _fposition + offset, bytes); break;
+		}
+		_fposition += bytes;
+		return bytes;
+	}
+
+protected:
+//private:
+
+	void serflashinit(void) {
+#if 0
+		pinMode(10,OUTPUT);
+		digitalWrite(10, HIGH);
+		pinMode(SERFLASH_CS,OUTPUT);
+		digitalWrite(SERFLASH_CS, HIGH);
+
+		SPI.setMOSI(7);
+		SPI.setMISO(12);
+		SPI.setSCK(14);
+#endif		
+		SPI.begin();
+		spisettings = SPISettings(SPICLOCK , MSBFIRST, SPI_MODE0);
+	}
+	void readserflash(uint8_t* buffer, const size_t position, const size_t bytes) {
+		SPI.beginTransaction(spisettings);
+		digitalWriteFast(SERFLASH_CS, LOW);
+		SPI.transfer(0x0b);//CMD_READ_HIGH_SPEED
+		SPI.transfer((position >> 16) & 0xff);
+		SPI.transfer((position >> 8) & 0xff);
+		SPI.transfer(position & 0xff);
+		SPI.transfer(0);
+		for(unsigned i = 0;i < bytes;i++) {
+			*buffer++ = SPI.transfer(0);
+		}
+		digitalWriteFast(SERFLASH_CS, HIGH);
+		SPI.endTransaction();
+	}
+
+	SPISettings spisettings;
+
+	codec_filetype ftype;
+
+	File file;
+	union {
+		uint8_t* fptr;
+		size_t offset;
+	};
+
+	size_t _fsize;
+	size_t _fposition;
+}; 

--- a/codecs.cpp
+++ b/codecs.cpp
@@ -110,7 +110,7 @@ size_t skipID3(uint8_t *sd_buf)
 	else return 0;
 }
 
-size_t AudioCodec::fillReadBuffer(File file, uint8_t *sd_buf, uint8_t *data, size_t dataLeft, size_t sd_bufsize)
+size_t AudioCodec::fillReadBuffer(uint8_t *sd_buf, uint8_t *data, size_t dataLeft, size_t sd_bufsize)
 {//TODO: Sync to 512-Byte blocks, if possible
 
 	memmove(sd_buf, data, dataLeft);

--- a/codecs.cpp
+++ b/codecs.cpp
@@ -40,55 +40,6 @@
 #include "codecs.h"
 
 #include "common/assembly.h"
-#include "SD.h"
-
-void CodecFile::serflashinit(void)
-{
-#if 0
-	pinMode(10,OUTPUT);
-	digitalWrite(10, HIGH);
-	pinMode(SERFLASH_CS,OUTPUT);
-	digitalWrite(SERFLASH_CS, HIGH);
-
-	SPI.setMOSI(7);
-	SPI.setMISO(12);
-	SPI.setSCK(14);
-#endif		
-	SPI.begin();
-	spisettings = SPISettings(SPICLOCK , MSBFIRST, SPI_MODE0);
-}
-
-//__attribute__ ((optimize("O2")))
-inline void CodecFile::readserflash(uint8_t* buffer, const size_t position, const size_t bytes)
-{//flash_spi.h has no such function.
-	SPI.beginTransaction(spisettings);
-	digitalWriteFast(SERFLASH_CS, LOW);
-	SPI.transfer(0x0b);//CMD_READ_HIGH_SPEED
-	SPI.transfer((position >> 16) & 0xff);
-	SPI.transfer((position >> 8) & 0xff);
-	SPI.transfer(position & 0xff);
-	SPI.transfer(0);
-	for(unsigned i = 0;i < bytes;i++) {
-		*buffer++ = SPI.transfer(0);
-	}
-	digitalWriteFast(SERFLASH_CS, HIGH);
-	SPI.endTransaction();
-}
-
-size_t CodecFile::fread(uint8_t buffer[],size_t bytes)
-{
-	if (_fposition + bytes > _fsize) bytes = _fsize - _fposition;
-	switch (ftype) {
-		case codec_none : bytes = 0; break;
-		case codec_file : bytes = file.read(buffer, bytes); break;
-		case codec_flash: memcpy(buffer, _fposition + fptr, bytes); break;
-		case codec_serflash: readserflash(buffer, _fposition + offset, bytes); break;
-	}
-	_fposition += bytes;
-	return bytes;
-}
-
-
 
 //Skip ID3-Tags at the beginning of the file.
 //http://id3.org/id3v2.4.0-structure

--- a/examples/AacFilePlayer/AacFilePlayer.ino
+++ b/examples/AacFilePlayer/AacFilePlayer.ino
@@ -49,7 +49,13 @@ void playFile(const char *filename)
 
 	// Start playing the file.  This sketch continues to
 	// run while the file plays.
-	playAac1.play(filename);
+  CodecFile file;
+  if(!file.fopen(filename)){
+    Serial.println("file not found");
+    return;
+  }
+
+  playAac1.play(&file);
 
 	// Simply wait for the file to finish playing.
 	while (playAac1.isPlaying()) {
@@ -79,7 +85,7 @@ void playFile(const char *filename)
 
 	delay(200);
   }
-  
+  file.fclose();
 
   
 }

--- a/examples/AacFilePlayer/AacFilePlayer.ino
+++ b/examples/AacFilePlayer/AacFilePlayer.ino
@@ -11,6 +11,7 @@
 #include <SD.h>
 
 #include <play_sd_aac.h> 
+#include <codecfile.h> // CodecFile implementation based on SD library
 
 // GUItool: begin automatically generated code
 AudioPlaySdAac           playAac1;       //xy=154,78

--- a/examples/AacFlashPlayer/AacFlashPlayer.ino
+++ b/examples/AacFlashPlayer/AacFlashPlayer.ino
@@ -15,6 +15,7 @@
 #include <SD.h>
 
 #include <play_sd_aac.h> 
+#include <codecfile.h> // CodecFile implementation based on SD library
 #include "enterauthorizationcode.h"
 
 

--- a/examples/AacFlashPlayer/AacFlashPlayer.ino
+++ b/examples/AacFlashPlayer/AacFlashPlayer.ino
@@ -44,7 +44,10 @@ void setup() {
 
 void loop() {
   Serial.println("Enter authorization code.\r\n");
-  playAac1.play((uint8_t*)&enterauthorizationcode_data, enterauthorizationcode_data_len);
+  CodecFile file;
+  file.fopen((uint8_t*)&enterauthorizationcode_data, enterauthorizationcode_data_len);
+  playAac1.play(&file);
   while (playAac1.isPlaying()) {;}
+  file.fclose();
   delay(2000);
 }

--- a/examples/Complete_MP3_AAC_MP4_M4A_example/Complete_MP3_AAC_MP4_M4A_example.ino
+++ b/examples/Complete_MP3_AAC_MP4_M4A_example/Complete_MP3_AAC_MP4_M4A_example.ino
@@ -31,6 +31,7 @@
 
 #include <play_sd_mp3.h> //mp3 decoder
 #include <play_sd_aac.h> // AAC decoder
+#include <codecfile.h> // CodecFile implementation based on SD library
 
 #define BUTTON1 2  //NEXT
 #define BUTTON2 3  //Play Pause

--- a/examples/Complete_MP3_AAC_MP4_M4A_example/Complete_MP3_AAC_MP4_M4A_example.ino
+++ b/examples/Complete_MP3_AAC_MP4_M4A_example/Complete_MP3_AAC_MP4_M4A_example.ino
@@ -168,8 +168,14 @@ void playFileMP3(const char *filename)
   // Start playing the file.  This sketch continues to
   // run while the file plays.
   EEPROM.write(0,track); //meanwhile write the track position to eeprom address 0
-  playMp31.play(filename);
 
+  CodecFile file;
+  if(!file.fopen(filename)){
+    Serial.println("file not found");
+    return;
+  }
+
+  playMp31.play(&file);
 
   // Simply wait for the file to finish playing.
   while (playMp31.isPlaying()) {
@@ -177,6 +183,7 @@ void playFileMP3(const char *filename)
     controls();
     serialcontrols();
   }
+  file.fclose();
 }
 
 void playFileAAC(const char *filename)
@@ -189,8 +196,14 @@ void playFileAAC(const char *filename)
   // Start playing the file.  This sketch continues to
   // run while the file plays.
   EEPROM.write(0,track); //meanwhile write the track position to eeprom address 0
-  playAac1.play(filename);
 
+  CodecFile file;
+  if(!file.fopen(filename)){
+    Serial.println("file not found");
+    return;
+  }
+
+  playAac1.play(&file);
 
   // Simply wait for the file to finish playing.
   while (playAac1.isPlaying()) {
@@ -198,6 +211,7 @@ void playFileAAC(const char *filename)
     controls();
     serialcontrols();
   }
+  file.fclose();
 }
 
 void controls() {

--- a/examples/FlacFilePlayer/FlacFilePlayer.ino
+++ b/examples/FlacFilePlayer/FlacFilePlayer.ino
@@ -49,7 +49,9 @@ void playFile(const char *filename)
 
   // Start playing the file.  This sketch continues to
   // run while the file plays.
-  playFlac1.play(filename);
+  CodecFile file;
+  file.fopen(filename);
+  playFlac1.play(&file);
 
   // Simply wait for the file to finish playing.
   while (playFlac1.isPlaying()) {
@@ -66,7 +68,7 @@ void playFile(const char *filename)
 #endif	
 	 delay(200); 
   }
-  
+  file.fclose();
 }
 
 

--- a/examples/FlacFilePlayer/FlacFilePlayer.ino
+++ b/examples/FlacFilePlayer/FlacFilePlayer.ino
@@ -11,7 +11,7 @@
 #include <SD.h>
 
 #include <play_sd_flac.h>
-
+#include <codecfile.h> // CodecFile implementation based on SD library
 
 // GUItool: begin automatically generated code
 AudioPlaySdFlac           playFlac1;       //xy=154,78

--- a/examples/Mp3FilePlayer/Mp3FilePlayer.ino
+++ b/examples/Mp3FilePlayer/Mp3FilePlayer.ino
@@ -23,6 +23,7 @@ AudioControlSGTL5000     sgtl5000_1;     //xy=240,153
 
 void setup() {
   Serial.begin(9600);
+  while(!Serial);
 
   // Audio connections require memory to work.  For more
   // detailed information, see the MemoryAndCpuUsage example
@@ -49,7 +50,13 @@ void playFile(const char *filename)
 
   // Start playing the file.  This sketch continues to
   // run while the file plays.
-  playMp31.play(filename);
+  CodecFile file;
+  if(!file.fopen(filename)){
+    Serial.println("file not found");
+    return;
+  }
+
+  playMp31.play(&file);
 
   // Simply wait for the file to finish playing.
   while (playMp31.isPlaying()) {
@@ -79,11 +86,12 @@ void playFile(const char *filename)
 	 
 	 delay(250);
   }
+  file.fclose();
 }
 
 
 void loop() {
-  playFile("ForTag.mp3");	
+  playFile("ForTag.mp3");
   playFile("Tom.mp3");
   playFile("Foreverm.mp3");
   delay(500);

--- a/examples/Mp3FilePlayer/Mp3FilePlayer.ino
+++ b/examples/Mp3FilePlayer/Mp3FilePlayer.ino
@@ -11,7 +11,7 @@
 #include <SD.h>
 
 #include <play_sd_mp3.h>
-
+#include <codecfile.h> // CodecFile implementation based on SD library
 
 // GUItool: begin automatically generated code
 AudioPlaySdMp3           playMp31;       //xy=154,78

--- a/play_sd_aac.cpp
+++ b/play_sd_aac.cpp
@@ -63,7 +63,6 @@ void AudioPlaySdAac::stop(void)
 	if (buf[0]) {free(buf[0]);buf[0] = NULL;}
 	freeBuffer();
 	if (hAACDecoder) {AACFreeDecoder(hAACDecoder);hAACDecoder=NULL;};
-	fclose();
 }
 
 uint32_t AudioPlaySdAac::lengthMillis(void)
@@ -240,7 +239,7 @@ int AudioPlaySdAac::play(void){
 	}
 
 	//Fill buffer from the beginning with fresh data
-	sd_left = fillReadBuffer(file, sd_buf, sd_buf, sd_left, AAC_SD_BUF_SIZE);
+	sd_left = fillReadBuffer(sd_buf, sd_buf, sd_left, AAC_SD_BUF_SIZE);
 
 	if (!sd_left) {
 		lastError = ERR_CODEC_FILE_NOT_FOUND;
@@ -366,7 +365,7 @@ void decodeAac(void)
 	case 0:
 		{
 
-			o->sd_left = o->fillReadBuffer( o->file, o->sd_buf, o->sd_p, o->sd_left, AAC_SD_BUF_SIZE);
+			o->sd_left = o->fillReadBuffer(o->sd_buf, o->sd_p, o->sd_left, AAC_SD_BUF_SIZE);
 			if (!o->sd_left) { eof = true; goto aacend; }
 			o->sd_p = o->sd_buf;
 

--- a/play_sd_aac.h
+++ b/play_sd_aac.h
@@ -54,10 +54,9 @@ class AudioPlaySdAac : public AudioCodec
 {
 public:
 	//AudioPlaySdAac(void) : AudioStream(0, NULL) {}
-	int play(const char *filename) {stop();if (!fopen(filename)) return ERR_CODEC_FILE_NOT_FOUND; return play();}
-	int play(const size_t p, const size_t size) {stop();if (!fopen(p,size)) return ERR_CODEC_FILE_NOT_FOUND; return play();}
-	int play(const uint8_t*p, const size_t size) {stop();if (!fopen(p,size))  return ERR_CODEC_FILE_NOT_FOUND; return play();}
 	void stop(void);
+	using AudioCodec::play;
+	int play(void);
 
 	uint32_t lengthMillis(void);
 
@@ -81,7 +80,6 @@ protected:
 	HAACDecoder		hAACDecoder;
 	AACFrameInfo	aacFrameInfo;
 
-	int play(void);
 	uint16_t fread16(size_t position);
 	uint32_t fread32(size_t position);
 	void setupDecoder(int channels, int samplerate, int profile);

--- a/play_sd_flac.cpp
+++ b/play_sd_flac.cpp
@@ -68,8 +68,6 @@ void AudioPlaySdFlac::stop(void)
 		FLAC__stream_decoder_delete(hFLACDecoder);
 		hFLACDecoder=NULL;
 	};
-
-	fclose();
 }
 
 

--- a/play_sd_flac.h
+++ b/play_sd_flac.h
@@ -51,10 +51,9 @@ class AudioPlaySdFlac : public AudioCodec
 {
 public:
 	//AudioPlaySdFlac(void){};
-	int play(const char *filename) {stop();if (!fopen(filename)) return ERR_CODEC_FILE_NOT_FOUND; return play();}
-	int play(const size_t p, const size_t size) {stop();if (!fopen(p,size)) return ERR_CODEC_FILE_NOT_FOUND; return play();}
-	int play(const uint8_t*p, const size_t size) {stop();if (!fopen(p,size))  return ERR_CODEC_FILE_NOT_FOUND; return play();}
 	void stop(void);
+	using AudioCodec::play;
+	int play(void);
 
 	uint32_t lengthMillis(void);
 	unsigned sampleRate(void);
@@ -64,8 +63,6 @@ protected:
 	AudioBuffer *audiobuffer;
 	uint16_t	minbuffers = 0;
 	static FLAC__StreamDecoder	*hFLACDecoder ;
-
-	int play(void);
 
 	friend FLAC__StreamDecoderWriteStatus write_callback(const FLAC__StreamDecoder *decoder, const FLAC__Frame *frame, const FLAC__int32 *const buffer[], void *client_data);
 	friend FLAC__StreamDecoderReadStatus read_callback(const FLAC__StreamDecoder *decoder, FLAC__byte buffer[], size_t *bytes, void *client_data);

--- a/play_sd_mp3.cpp
+++ b/play_sd_mp3.cpp
@@ -62,7 +62,6 @@ void AudioPlaySdMp3::stop(void)
 	if (buf[0]) {free(buf[0]);buf[0] = NULL;}
 	freeBuffer();
 	if (hMP3Decoder) {MP3FreeDecoder(hMP3Decoder);hMP3Decoder=NULL;};
-	fclose();
 }
 /*
 float AudioPlaySdMp3::processorUsageMaxDecoder(void){
@@ -117,7 +116,7 @@ int AudioPlaySdMp3::play(void)
 	} else size_id3 = 0;
 
 	//Fill buffer from the beginning with fresh data
-	sd_left = fillReadBuffer(file, sd_buf, sd_buf, sd_left, MP3_SD_BUF_SIZE);
+	sd_left = fillReadBuffer(sd_buf, sd_buf, sd_left, MP3_SD_BUF_SIZE);
 
 	if (!sd_left) {
 		lastError = ERR_CODEC_FILE_NOT_FOUND;
@@ -246,7 +245,7 @@ void decodeMp3(void)
 	case 0:
 		{
 
-			o->sd_left = o->fillReadBuffer( o->file, o->sd_buf, o->sd_p, o->sd_left, MP3_SD_BUF_SIZE);
+			o->sd_left = o->fillReadBuffer(o->sd_buf, o->sd_p, o->sd_left, MP3_SD_BUF_SIZE);
 			if (!o->sd_left) { eof = true; goto mp3end; }
 			o->sd_p = o->sd_buf;
 

--- a/play_sd_mp3.h
+++ b/play_sd_mp3.h
@@ -50,9 +50,8 @@ class AudioPlaySdMp3 : public AudioCodec
 {
 public:
 	void stop(void);
-	int play(const char *filename) {stop();if (!fopen(filename)) return ERR_CODEC_FILE_NOT_FOUND; return play();}
-	int play(const size_t p, const size_t size) {stop();if (!fopen(p,size)) return ERR_CODEC_FILE_NOT_FOUND; return play();}
-	int play(const uint8_t*p, const size_t size) {stop();if (!fopen(p,size))  return ERR_CODEC_FILE_NOT_FOUND; return play();}
+	using AudioCodec::play;
+	int play(void);
 
 protected:
 	uint8_t			*sd_buf;
@@ -70,7 +69,6 @@ protected:
 	HMP3Decoder		hMP3Decoder;
 	MP3FrameInfo	mp3FrameInfo;
 
-	int play(void);
 	void update(void);
 	friend void decodeMp3(void);
 };


### PR DESCRIPTION
Make CodecFile a helper object passed into AudioCodec rather than a base class of AudioCodec and move the implementation to codecfile.h (new file), It has to be in a header file so the SD.h dependency doesn't get compiled into the library. I also created a CodecFileBase interface that is implemented by CodecFile or [your own class that implements the CodeFileBase interface](https://github.com/jcj83429/teensy_audio_player/blob/master/mycodecfile.h). The changes in this PR alone won't allow you to use a different SD library. You also need to remove play_sd_wav.cpp/h and play_sd_raw.cpp/h from the teensy audio library to fully remove all dependencies on SD.h.

The play() interface had to be changed to take a CodecFileBase pointer. It is the user's responsibility to open and close the file if needed. The CodecFileBase interface doesn't manage fopen/fclose.

I updated and tested all the examples.